### PR TITLE
Bump build number for corrupt linux package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 029bdc476a069fda2cea3cd937ba19cc7fa614fb90578caef98ed703b658f4a1
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win and py27]
   skip: true  # [ppc64le]
   merge_build_host: true  # [linux]


### PR DESCRIPTION
The linux package seems to have become corrupt (mismatching sha256).
After inspection of the package it seems to have all the correct
files and hashes, however probably good to take percaution and
rebuild/upload the package

ref: https://conda.anaconda.org/conda-forge/linux-64/qscintilla2-2.11.2-py37h73816c6_1.tar.bz2
ref: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=85728

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
